### PR TITLE
Add global backup export option

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -780,6 +780,10 @@ function renderAjustes() {
         <label><input type="checkbox" id="chk-privacidad" ${privacidad ? 'checked' : ''}/> Ocultar cantidades</label>
         <button id="btn-save-privacidad" class="btn">Guardar privacidad</button>
       </section>
+      <section>
+        <h3>Exportar datos</h3>
+        <button id="btn-exportar-datos" class="btn">Exportar Backup</button>
+      </section>
     </div>`;
 
   document.getElementById('btn-save-brokers').onclick = () => {
@@ -835,6 +839,9 @@ function renderAjustes() {
     setPrivacidad(activo);
     alert('Preferencia de privacidad guardada.');
   };
+
+  const btnExp = document.getElementById('btn-exportar-datos');
+  if (btnExp) btnExp.onclick = exportarBackup;
 }
 
 function renderInfo() {
@@ -1013,6 +1020,20 @@ function parseCSV(text) {
     headers.forEach((h,i)=> obj[h] = (cols[i] || '').trim());
     return obj;
   });
+}
+
+async function exportarBackup() {
+  const backup = {};
+  for (const tabla of db.tables) {
+    backup[tabla.name] = await tabla.toArray();
+  }
+  const blob = new Blob([JSON.stringify(backup)], {
+    type: 'application/json'
+  });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `carteraPRO_backup_${new Date().toISOString().slice(0,10)}.json`;
+  a.click();
 }
 
 // ----- Modal Movimientos -----

--- a/js/app.js
+++ b/js/app.js
@@ -844,38 +844,36 @@ function renderAjustes() {
   if (btnExp) btnExp.onclick = exportarBackup;
 }
 
-function renderInfo() {
+async function renderInfo() {
   app.innerHTML = `<div class="card"><h2>Información</h2><div id="info-cont">Cargando...</div></div>`;
-  fetch('version.json', { cache: 'no-store' })
-    .then(r => r.json())
-    .then(local => {
-      const fecha = local.date || '';
-      const instalada = local.version;
-      fetch(
+  try {
+    const localResp = await fetch('version.json', { cache: 'no-store' });
+    const local = await localResp.json();
+    const fecha = local.date || '';
+    const instalada = local.version || '';
+    try {
+      const remoteResp = await fetch(
         'https://raw.githubusercontent.com/Adriamo1/CarteraPro/main/version.json',
         { cache: 'no-store' }
-      )
-        .then(r => r.json())
-        .then(remoto => {
-          const ultima = remoto.version;
-          document.getElementById('info-cont').innerHTML = `
-            <p>Versión instalada: ${instalada}</p>
-            <p>Última versión disponible: ${ultima}</p>
-            <p>Fecha de creación: ${fecha}</p>
-            <p>Creado por <a href="https://www.adrianmonge.es" target="_blank" rel="noopener">Adrián Monge</a></p>
-            <p><a href="https://github.com/adrianmonge/CarteraPro" target="_blank" rel="noopener">Repositorio del proyecto</a></p>`;
-        })
-        .catch(() => {
-          document.getElementById('info-cont').innerHTML = `
-            <p>Versión instalada: ${instalada}</p>
-            <p>Fecha de creación: ${fecha}</p>
-            <p>Creado por <a href="https://www.adrianmonge.es" target="_blank" rel="noopener">Adrián Monge</a></p>
-            <p><a href="https://github.com/adrianmonge/CarteraPro" target="_blank" rel="noopener">Repositorio del proyecto</a></p>`;
-        });
-    })
-    .catch(() => {
-      document.getElementById('info-cont').textContent = 'No disponible';
-    });
+      );
+      const remoto = await remoteResp.json();
+      const ultima = remoto.version;
+      document.getElementById('info-cont').innerHTML = `
+        <p>Versión instalada: ${instalada}</p>
+        <p>Última versión disponible: ${ultima}</p>
+        <p>Fecha de creación: ${fecha}</p>
+        <p>Creado por <a href="https://www.adrianmonge.es" target="_blank" rel="noopener">Adrián Monge</a></p>
+        <p><a href="https://github.com/adrianmonge/CarteraPro" target="_blank" rel="noopener">Repositorio del proyecto</a></p>`;
+    } catch {
+      document.getElementById('info-cont').innerHTML = `
+        <p>Versión instalada: ${instalada}</p>
+        <p>Fecha de creación: ${fecha}</p>
+        <p>Creado por <a href="https://www.adrianmonge.es" target="_blank" rel="noopener">Adrián Monge</a></p>
+        <p><a href="https://github.com/adrianmonge/CarteraPro" target="_blank" rel="noopener">Repositorio del proyecto</a></p>`;
+    }
+  } catch {
+    document.getElementById('info-cont').textContent = 'No disponible';
+  }
 }
 
 // --------- Gráficos Dashboard ---------

--- a/service-worker.js
+++ b/service-worker.js
@@ -8,7 +8,8 @@ const urlsToCache = [
   '/icon192.png',
   '/icon512.png',
   // Añade tus scripts si quieres cachearlos:
-  '/js/app.js'
+  '/js/app.js',
+  '/version.json'
   // Añade widgets y vistas según vayas completando
 ];
 
@@ -21,7 +22,9 @@ self.addEventListener('install', function(event) {
 
 self.addEventListener('fetch', function(event) {
   if (event.request.url.endsWith('version.json')) {
-    event.respondWith(fetch(event.request));
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(event.request))
+    );
     return;
   }
   event.respondWith(


### PR DESCRIPTION
## Summary
- add `exportarBackup()` to build a JSON backup with all tables
- expose new export button in Ajustes and attach handler

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_687c13a0f538832e87ab1808ba8c4eaa