### PR TITLE
Improve offline version handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,12 @@
   <script src="https://cdn.jsdelivr.net/npm/dexie@3.2.3/dist/dexie.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="js/app.js"></script>
+  <script id="version-data" type="application/json">
+    {
+      "version": "alpha 0.7.1.4",
+      "date": "2025-07-19"
+    }
+  </script>
   <script>
     const anioEl = document.getElementById('anio');
     if (anioEl) anioEl.textContent = new Date().getFullYear();

--- a/js/app.js
+++ b/js/app.js
@@ -847,8 +847,14 @@ function renderAjustes() {
 async function renderInfo() {
   app.innerHTML = `<div class="card"><h2>Información</h2><div id="info-cont">Cargando...</div></div>`;
   try {
-    const localResp = await fetch('version.json', { cache: 'no-store' });
-    const local = await localResp.json();
+    let local;
+    try {
+      const localResp = await fetch('version.json', { cache: 'no-store' });
+      local = await localResp.json();
+    } catch {
+      const el = document.getElementById('version-data');
+      local = el ? JSON.parse(el.textContent) : {};
+    }
     const fecha = local.date || '';
     const instalada = local.version || '';
     try {


### PR DESCRIPTION
## Summary
- embed version data in `index.html`
- use local JSON fallback in `renderInfo`

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_687c1863f220832eaa119f628e26ed66