### PR TITLE
Add search filters to asset and transaction tables

### DIFF
--- a/style.css
+++ b/style.css
@@ -364,3 +364,14 @@ footer {
   width: 90%;
   max-width: 400px;
 }
+
+/* ----- Filtros ----- */
+.filtros-table {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  margin: var(--gap-sm) 0;
+}
+.filtros-table input[type="search"] {
+  flex: 1 1 160px;
+}


### PR DESCRIPTION
## Summary
- implement real-time search and dropdown filters in Activos table
- add same filtering for Transacciones
- style new filter controls

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_687c99fa6fd0832eab071728cca1c8d7