### PR TITLE
Fix section rendering without Chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   <script src="js/app.js"></script>
   <script id="version-data" type="application/json">
     {
-      "version": "alpha 0.7.1.7",
+      "version": "alpha 0.7.1.8",
       "date": "2025-07-21"
     }
   </script>

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,7 @@ const state = {
   interestRates: [],
   settings: { lastExchangeUpdate: null }
 };
+const hasChart = typeof Chart !== 'undefined';
 
 // Cola simple para peticiones API secuenciales
 const apiQueue = [];
@@ -571,7 +572,7 @@ async function renderActivos() {
     attachRowHandlers();
   }
 
-  if (modo === 'detalle') {
+  if (hasChart && modo === 'detalle') {
     for (const a of activos) {
       const trans = await db.transacciones.where('activoId').equals(a.id).toArray();
       const ctx = document.getElementById(`graf-act-${a.id}`).getContext('2d');
@@ -1172,6 +1173,7 @@ async function datosEvolucionCartera() {
 }
 
 async function renderGraficosDashboard() {
+  if (!hasChart) return;
   const pnl = await calcularPnLPorActivo();
   const ctxPnl = document.getElementById('grafico-pnl').getContext('2d');
   new Chart(ctxPnl, {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // service-worker.js
-const CACHE_NAME = 'cartera-pro-valpha-0.7.1.7';
+const CACHE_NAME = 'cartera-pro-valpha-0.7.1.8';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -9,6 +9,8 @@ const urlsToCache = [
   '/icon512.png',
   // Añade tus scripts si quieres cachearlos:
   '/js/app.js',
+  'https://cdn.jsdelivr.net/npm/dexie@3.2.3/dist/dexie.min.js',
+  'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js',
   '/version.json'
 ];
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "alpha 0.7.1.7",
+  "version": "alpha 0.7.1.8",
   "date": "2025-07-21"
 }


### PR DESCRIPTION
## Summary
- add guard for Chart library with `hasChart`
- skip dashboard chart rendering if Chart isn't available
- only render asset charts if Chart is loaded
- update version to 0.7.1.8
- pre-cache external JS libraries in the service worker

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_687ca0f1676c832e9c7fb3717fab5526