### PR TITLE
Implement annualized return and glossary features

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <li><a href="#deudas" data-icon="🏦"><span>Deudas</span></a></li>
         <li><a href="#tiposcambio" data-icon="💱"><span>Tipos de cambio</span></a></li>
         <li><a href="#analisisvalue" data-icon="📚"><span>Análisis Value</span></a></li>
+        <li><a href="#glosario" data-icon="❓"><span>Glosario</span></a></li>
         <li><a href="#info" data-icon="ℹ️"><span>Información</span></a></li>
         <li><a href="#view-settings" data-icon="⚙️"><span>Ajustes</span></a></li>
       </ul>

--- a/style.css
+++ b/style.css
@@ -375,3 +375,19 @@ footer {
 .filtros-table input[type="search"] {
   flex: 1 1 160px;
 }
+
+/* ----- Ayudas y alertas ----- */
+.help {
+  cursor: help;
+  border-bottom: 1px dotted var(--color-muted);
+}
+
+.alert {
+  background: var(--sidebar-bg);
+  padding: var(--gap-sm);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--gap-md);
+  font-weight: bold;
+}
+.alert.cumplido { color: var(--color-positivo); }
+.alert.pendiente { color: var(--color-negativo); }


### PR DESCRIPTION
## Summary
- add glossary page to navigation
- compute annualized return from portfolio history
- display goal alerts and reset button on dashboard
- add help tooltips and glossary page
- allow custom asset types via select

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_687cd51c13c8832eab3f07b6002f91a9