### PR TITLE
Add debug view

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <li><a href="#analisisvalue" data-icon="📚"><span>Análisis Value</span></a></li>
         <li><a href="#glosario" data-icon="❓"><span>Glosario</span></a></li>
         <li><a href="#info" data-icon="ℹ️"><span>Información</span></a></li>
+        <li><a href="#debug" data-icon="🐞"><span>Debug</span></a></li>
         <li><a href="#view-settings" data-icon="⚙️"><span>Ajustes</span></a></li>
       </ul>
     </nav>

--- a/js/app.js
+++ b/js/app.js
@@ -320,6 +320,7 @@ const vistas = {
   "#analisisvalue": renderAnalisisValue,
   "#glosario": renderGlosario,
   "#info": renderInfo,
+  "#debug": renderDebug,
   "#resumen": renderResumen,
   "#ajustes": renderAjustes,
   "#view-settings": renderAjustes
@@ -1531,6 +1532,24 @@ function renderGlosario() {
   const lista = Object.entries(defs)
     .map(([t,d]) => `<dt>${t}</dt><dd>${d}</dd>`).join('');
   app.innerHTML = `<div class="card"><h2>Glosario financiero</h2><dl>${lista}</dl></div>`;
+}
+
+async function renderDebug() {
+  if (!appState) await cargarEstado();
+  const size = JSON.stringify(appState).length;
+  const assets = appState.assets.length;
+  const trans = appState.transactions.length;
+  const lastTc = state.settings.lastExchangeUpdate ? new Date(state.settings.lastExchangeUpdate).toLocaleString() : 'N/A';
+  const lastHist = appState.portfolioHistory.slice(-1)[0]?.fecha || 'N/A';
+  app.innerHTML = `
+    <div class="card">
+      <h2>Estado de la app</h2>
+      <p>Tamaño del state: ${size} bytes</p>
+      <p>Activos registrados: ${assets}</p>
+      <p>Transacciones registradas: ${trans}</p>
+      <p>Última actualización de TC: ${lastTc}</p>
+      <p>Último histórico de cartera: ${lastHist}</p>
+    </div>`;
 }
 
 // --------- Gráficos Dashboard ---------


### PR DESCRIPTION
## Summary
- add Debug section to sidebar navigation
- show app state metrics via new renderDebug view

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_687cd9a4f208832e83f729ab12bcd6a7