### PR TITLE
Add edit/delete modals for incomes and expenses

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
         <li><a href="#inicio" data-icon="📊"><span>Inicio</span></a></li>
         <li><a href="#activos" data-icon="📈"><span>Activos</span></a></li>
         <li><a href="#transacciones" data-icon="💸"><span>Transacciones</span></a></li>
+        <li><a href="#ingresos" data-icon="💰"><span>Ingresos</span></a></li>
+        <li><a href="#gastos" data-icon="🛒"><span>Gastos</span></a></li>
         <li><a href="#cuentas" data-icon="💳"><span>Cuentas</span></a></li>
         <li><a href="#deudas" data-icon="🏦"><span>Deudas</span></a></li>
         <li><a href="#tiposcambio" data-icon="💱"><span>Tipos de cambio</span></a></li>


### PR DESCRIPTION
## Summary
- add `Ingresos` and `Gastos` sections to the sidebar
- map new hashes `#ingresos` and `#gastos` to render functions
- implement `renderIngresos` and `renderGastos` with edit/delete buttons
- create new modals for adding and editing incomes or expenses

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_687d1b5b4748832e9766c333894da5c0