### PR TITLE
Add data import/export options

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/dexie@3.2.3/dist/dexie.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="js/app.js"></script>
   <script id="version-data" type="application/json">
     {


### PR DESCRIPTION
## Summary
- include PapaParse via CDN
- use PapaParse to handle CSV
- allow exporting and importing full data as JSON from settings
- new buttons to export/import transaction CSVs

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_687d207eba6c832e8b64b5207aee06bf