### PR TITLE
Update menu and embed sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,15 +19,12 @@
         <li><a href="#inicio" data-icon="📊"><span>Inicio</span></a></li>
         <li><a href="#activos" data-icon="📈"><span>Activos</span></a></li>
         <li><a href="#transacciones" data-icon="💸"><span>Transacciones</span></a></li>
-        <li><a href="#ingresos" data-icon="💰"><span>Ingresos</span></a></li>
-        <li><a href="#gastos" data-icon="🛒"><span>Gastos</span></a></li>
         <li><a href="#cuentas" data-icon="💳"><span>Cuentas</span></a></li>
         <li><a href="#deudas" data-icon="🏦"><span>Deudas</span></a></li>
         <li><a href="#tiposcambio" data-icon="💱"><span>Tipos de cambio</span></a></li>
         <li><a href="#analisisvalue" data-icon="📚"><span>Análisis Value</span></a></li>
         <li><a href="#glosario" data-icon="❓"><span>Glosario</span></a></li>
         <li><a href="#info" data-icon="ℹ️"><span>Información</span></a></li>
-        <li><a href="#debug" data-icon="🐞"><span>Debug</span></a></li>
         <li><a href="#view-settings" data-icon="⚙️"><span>Ajustes</span></a></li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
- remove standalone Ingresos, Gastos and Debug from sidebar
- integrate debug info inside Información
- show incomes and expenses within Transacciones view

## Testing
- `python3 -m http.server 8001 >/tmp/server.log 2>&1 &`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_687d2df77b00832e9656f457678e5591